### PR TITLE
Update Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "213eb6887e526e0dfac526a2eae559a1893ebbac",
+          "version": "2.36.0"
         }
       }
     ]


### PR DESCRIPTION
With the current version, of SwiftNIO it throws compile error:
`~/NioDNS/Sources/DNSClient/DNSClient+Connect.swift:68:22: Value of type 'SocketAddress' has no member 'protocol'`